### PR TITLE
Add schema.org

### DIFF
--- a/webserver/views/champion.handlebars
+++ b/webserver/views/champion.handlebars
@@ -11,6 +11,24 @@
 			most champion mastery points on {{champion.name}}
 		{{~/eq ~}}
 	{{/content}}
+	
+	{{#content "schema.org"}}
+		<script type=application/ld+json>
+			{
+				"@context": "http://schema.org",
+				"@type": "Person",
+				"name": "{{champion.name}}",
+				"image": "/img/championIcons/{{champion.icon}}",
+				"sameAs": [
+					"https://www.leagueoflegends.com/en-us/champions/{{#replace (lowercare champion.name) " " "-"}}/",
+					"https://leagueoflegends.fandom.com/wiki/{{#replace champion.name " " "_"}}",
+					"https://www.mobafire.com/league-of-legends/champion/{{#replace (lowercare champion.name) " " "-"}}-{{champion.id}}",
+					"https://u.gg/lol/champions/{{#replace (lowercare champion.name) " " ""}}",
+					"https://www.op.gg/champion/{{#replace (lowercare champion.name) " " ""}}"
+				]
+			}
+		</script>
+	{{/content}}
 
 	{{#content "css"}}
 		<link rel="stylesheet" type="text/css" href="/css/champion.css">

--- a/webserver/views/highscores.handlebars
+++ b/webserver/views/highscores.handlebars
@@ -31,7 +31,7 @@
 		<div class="ad-header vm-placement"></div>
 		<div id="highscores">
 			{{#each highscores}}
-				<div class="champion well">
+				<div class="champion well" itemscope itemtype="https://schema.org/Person">
 					<div class="champion-icon">
 						<a href="/champion?champion={{this.id}}">
 							<span class="championSpritesheet" style='background: url("/img/championSpritesheet.png") 0 -{{this.spritesheetY}}px'></span>
@@ -39,7 +39,7 @@
 					</div>
 					<div class="champion-info">
 						<a href="/champion?champion={{this.id}}">
-							<strong>{{this.name}}</strong>
+							<strong itemprop="name">{{this.name}}</strong>
 						</a>
 						{{#each this.scores}}
 							<div>

--- a/webserver/views/layout.handlebars
+++ b/webserver/views/layout.handlebars
@@ -25,6 +25,7 @@
 	<link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
 	<meta name="msapplication-TileColor" content="#00aba9">
 	<meta name="theme-color" content="#ffffff">
+	{{{block "schema.org"}}}
 	<link rel="stylesheet" type="text/css" href="/css/styles.css">
 	{{{block "css"}}}
 	<script src="/js/script.js"></script>

--- a/webserver/views/summoner.handlebars
+++ b/webserver/views/summoner.handlebars
@@ -3,7 +3,23 @@
 		{{summoner.name}} ({{summoner.region}}) - ChampionMastery.GG
 	{{/content}}
 
-	{{#content "meta-description"}}Champion mastery scores for {{summoner.name}} ({{summoner.region}}){{/content}}
+	{{#content "meta-description"}}Champion mastery scores for {{summoner.name}} ({{summoner.region}}){{/content}}	
+	
+	{{#content "schema.org"}}
+		<script type=application/ld+json>
+			{
+				"@context": "http://schema.org",
+				"@type": "Person",
+				"name": "{{summoner.name}}",
+				"image": "/img/profileIcons/{{summoner.icon}}.png",
+				"sameAs": [
+					"https://{{summoner.region}}.op.gg/summoner/userName={{encodeURI summoner.name}}",
+					"https://www.leagueofgraphs.com/summoner/{{lowercase summoner.region}}/{{encodeURI summoner.name}}",
+					"https://u.gg/lol/profile/{{lowercase summoner.platform}}/{{encodeURI (lowercase summoner.name)}}/overview"
+				]
+			}
+		</script>
+	{{/content}}
 
 	{{#content "css"}}
 		<link rel="stylesheet" type="text/css" href="/css/summoner.css">


### PR DESCRIPTION
# What's schema.org?
[Schema.org](https://schema.org/) is a collaborative, community activity with a mission to create, maintain, and promote schemas for structured data on the Internet, on web pages, in email messages, and beyond. Founded by Google, Microsoft, Yahoo and Yandex. 

# Why?
Improved visibility on search engines. There are certain keywords schema.org markup could help with, e.g. "[nocturne (league of legends)](https://www.google.com/search?q=nocturne+%28league+of+legends%29)". Clearly telling the search engines that the Nocturne page is about Nocturne from League of Legends should improve ranking for that search while making certain ChampionMastery.GG disappears from searches like "[nocturne (2020 film)](https://www.google.com/search?q=nocturne+%282020+film%29)".

# Why not?
ChampionMastery.GG already has great ranking and visibility. Because of this there could be unintended negative consequences (?).

![image](https://user-images.githubusercontent.com/3706841/152649726-9ca829b0-ec54-438e-ba94-c7f1b2d0d034.png)

# To-Do List

- [x] Highscores
  - [ ] Wells
- [x] Champion
  - [ ] Table
- [x] Summoner
  - [ ] Table
- [ ] Home
- [ ] FAQ
- [ ] Legal
- [ ] Privacy
- [ ] https://schema.org/WebPage
- [ ] [Google Schema Markup Testing Tool](https://developers.google.com/search/docs/advanced/structured-data)