### PR TITLE
Use Date format based on browser language settings

### DIFF
--- a/webserver/public/js/summoner.js
+++ b/webserver/public/js/summoner.js
@@ -7,13 +7,13 @@ const timeUnits = [
 	{value: 1000 * 60 * 60 * 24 * 365, name: "year", max: 100}
 ];
 
-const dateFormatter = new Intl.DateTimeFormat([], {
+const dateFormatter = new Intl.DateTimeFormat(navigator.languages || [], {
 	year: "2-digit",
 	month: "numeric",
 	day: "numeric"
 });
 
-const timeFormatter = new Intl.DateTimeFormat([], {
+const timeFormatter = new Intl.DateTimeFormat(navigator.languages || [], {
 	hour: "numeric",
 	minute: "numeric"
 });


### PR DESCRIPTION
Fall back to current behaviour if that information doesn't exist for whatever reason. This would personally help the readability of the site for me quite a bit.